### PR TITLE
modified Dockerfile to deal with the error when executing docker build

### DIFF
--- a/Dell/benchmarks/bert/implementations/pytorch/Dockerfile
+++ b/Dell/benchmarks/bert/implementations/pytorch/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG FROM_IMAGE_NAME=nvcr.io/nvdlfwea/pytorch:23.09-py3
+ARG FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:23.09-py3
 
 FROM ${FROM_IMAGE_NAME}
 


### PR DESCRIPTION
In Dockerfile, there is the line below

> ARG FROM_IMAGE_NAME=nvcr.io/nvdlfwea/pytorch:23.09-py3

I think it's typo and it cause the error of docker build command.